### PR TITLE
Correct Ribbon35.dll HintPath

### DIFF
--- a/LogLauncher.csproj
+++ b/LogLauncher.csproj
@@ -65,7 +65,7 @@
     <Reference Include="System.Design" />
     <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Windows.Forms.Ribbon35">
-      <HintPath>.\System.Windows.Forms.Ribbon35.dll</HintPath>
+      <HintPath>Resources\System.Windows.Forms.Ribbon35.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
System.Windows.Forms.Ribbon35.dll's HintPath pointed to the root directory rather than the Resources folder, where it's actually saved. Alternatively, it might be better to just install from nuget, since nuget's already in use for ILRepack? https://www.nuget.org/packages/System.Windows.Forms.Ribbon35