### PR TITLE
Change requestedExecutionLevel to asInvoker

### DIFF
--- a/app.manifest
+++ b/app.manifest
@@ -5,18 +5,18 @@
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
         <!-- UAC Manifest Options
-             If you want to change the Windows User Account Control level replace the 
+             If you want to change the Windows User Account Control level replace the
              requestedExecutionLevel node with one of the following.
 
         <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
         <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
         <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
 
-            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Specifying requestedExecutionLevel element will disable file and registry virtualization.
             Remove this element if your application requires this virtualization for backwards
             compatibility.
         -->
-        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
       </requestedPrivileges>
     </security>
   </trustInfo>
@@ -24,7 +24,7 @@
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!-- A list of the Windows versions that this application has been tested on and is
-           is designed to work with. Uncomment the appropriate elements and Windows will 
+           is designed to work with. Uncomment the appropriate elements and Windows will
            automatically selected the most compatible environment. -->
 
       <!-- Windows Vista -->
@@ -46,8 +46,8 @@
   </compatibility>
 
   <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
-       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
-       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should
        also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
   <!--
   <application xmlns="urn:schemas-microsoft-com:asm.v3">


### PR DESCRIPTION
Currently Log Launcher cannot be used by non-admin users, since the
current requestedExecutionLevel of "requireAdministrator" means it
will always attempt to elevate. Change the requestedExecutionLevel to
"asInvoker" to allow it to run without elevation in the user's
normal context.

asInvoker was chosen over highestAvailable to not elevate unless
necessary, and users can still manually launch elevated. When used to
inspect a remote computer's logs, local elevation makes no difference.

I went for asInvoker as, in my experience, the tool's used almost entirely to view another computer's logs, but if you feel a local administrator viewing their local machine's log files is a sufficiently common usage that having to manually elevate is unreasonable, highestAvailable may be a better option.